### PR TITLE
Fix "Error: Cannot find module 'co'" exception when requiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     ]
   },
   "devDependencies": {
-    "co": "^4.6.0",
     "eslint": "^1.10.3",
     "eslint-config-features": "^1.1.5",
     "eslint-config-js": "^2.0.2",
@@ -47,6 +46,7 @@
     "cli.js"
   ],
   "dependencies": {
+    "co": "^4.6.0",
     "debug": "^2.2.0",
     "ssh2": "^0.4.12",
     "yargs": "^3.30.0"


### PR DESCRIPTION
Got this error when requiring the latest NPM build:

```
$ node .
module.js:328
    throw err;
    ^

Error: Cannot find module 'co'
    at Function.Module._resolveFilename (module.js:326:15)
    at Function.Module._load (module.js:277:25)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/joshuabalfour/projectName/node_modules/open-ssh-tunnel/index.js:6:12)
    at Module._compile (module.js:398:26)
    at Object.Module._extensions..js (module.js:405:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
```

Turns out co was under devDependancies, so I moved it to dependancies, and now it works lovely.

Cheers for the module 👍🏻
